### PR TITLE
Event namespace

### DIFF
--- a/rpi_cam_app/include/camera_device/CameraInitializer.hpp
+++ b/rpi_cam_app/include/camera_device/CameraInitializer.hpp
@@ -10,8 +10,6 @@
 
 namespace camera_device
 {
-
-
     class CameraInitializer : public utils::Initialzier
     {
     private:

--- a/rpi_cam_app/include/event/EventHandler.hpp
+++ b/rpi_cam_app/include/event/EventHandler.hpp
@@ -1,0 +1,30 @@
+#ifndef _EVENT_HANDLER_H
+#define _EVENT_HANDLER_H
+
+#include <unordered_map>
+#include "event/EventProcessor.hpp"
+#include "camera_device/VideoQueue.hpp"
+#include "utils/Singleton.hpp"
+
+namespace event
+{
+    class EventProcessor;
+    
+    class EventHandler :public utils::Singleton<EventHandler>
+    {
+    private:
+        std::unordered_map< std::string, EventProcessor* > _event_thread;
+
+        camera_device::VideoQueue* _video_q;
+
+        friend utils::Singleton<EventHandler>;
+        
+        EventHandler();
+        
+    public:
+        int start_event(std::string name);
+        int stop_event(std::string name);
+    };
+};
+
+#endif

--- a/rpi_cam_app/include/event/EventInitializer.hpp
+++ b/rpi_cam_app/include/event/EventInitializer.hpp
@@ -1,0 +1,32 @@
+#ifndef _EVENT_INIT_H
+#define _EVENT_INIT_H
+
+#include "utils/Initializer.hpp"
+#include "event/EventHandler.hpp"
+#include <vector>
+
+namespace event
+{
+    class EventInitializer: public utils::Initialzier
+    {
+    private:
+        EventHandler* _event_handler;
+        std::vector<std::string> _event_names;
+
+    public:
+        EventInitializer();
+
+        /// @brief 파일에 있는 이벤트들 읽어옴
+        /// @return 0 성공
+        int init() override;
+        /// @brief 시작 로그 남김
+        /// @return 0 성공
+        int start() override;
+
+        /// @brief 이벤트 스레드 종료
+        /// @return 0 성공
+        int stop() override;
+    };
+};
+
+#endif

--- a/rpi_cam_app/include/event/EventProcessor.hpp
+++ b/rpi_cam_app/include/event/EventProcessor.hpp
@@ -1,0 +1,44 @@
+#ifndef _EVENT_PROCESS_H
+#define _EVENT_PROCESS_H
+
+#include <string>
+#include <cstdint>
+#include <ctime>
+#include "http/EventHandlerHTTP.hpp"
+#include "camera_device/VideoQueue.hpp"
+
+// forward declaration
+namespace http {
+class EventHandlerHTTP;
+}
+namespace event
+{
+    typedef int (*event_function)(uint8_t* buffer, size_t size, time_t timestamp, int width, int height);
+    
+    class EventProcessor
+    {
+    private:
+
+        std::string _event_name;
+        int _fps;
+        bool _enable;
+        event_function _event_program = nullptr;
+        camera_device::ThreadInfo* _info;
+        void* _handle;
+
+        camera_device::VideoQueue* _video_q;
+        http::EventHandlerHTTP* _event_handler;
+
+        int event_init();
+        int event_exec(camera_device::VideoBuffer* buffer);
+
+    public:
+        EventProcessor() = delete;
+        EventProcessor(std::string event_name);
+
+        int event_loop();
+
+    };
+}; // namespace event
+
+#endif

--- a/rpi_cam_app/include/http/EventHandlerHTTP.hpp
+++ b/rpi_cam_app/include/http/EventHandlerHTTP.hpp
@@ -10,6 +10,7 @@
 #include "utils/Singleton.hpp"
 #include "config/ProgramConfig.hpp"
 #include "video/VideoHandler.hpp"
+#include "event/EventHandler.hpp"
 
 namespace http
 {
@@ -49,13 +50,15 @@ namespace http
 
         video::VideoHandler* _video_handler = video::VideoHandler::get_instance();
 
+        event::EventHandler* _event_handler = event::EventHandler::get_instance();
+
         friend class utils::Singleton<EventHandlerHTTP>;
 
         EventHandlerHTTP();
         
         MHD_Result send_response(MHD_Connection* conn, const std::string& buffer, int status);
-
         int send_request(CURL* curl, const std::string& url, const std::string& payload);
+
     public:
         std::mutex& upload_client_mutex();
         
@@ -81,6 +84,20 @@ namespace http
         /// @param size http 데이터 크기
         /// @return 0:성공, others:실패
         int program_accept(MHD_Connection* conn, const char* data, size_t* size, void** con_cls);
+
+        /// @brief 이벤트 프로그램 실행
+        /// @param conn MHD_Connection
+        /// @param data http 데이터
+        /// @param size http 데이터 크기
+        /// @return 0:성공, others:실패
+        int program_start_accept(MHD_Connection* conn, const char* data, size_t* size, void** con_cls);
+        
+        /// @brief 이벤트 프로그램 중지
+        /// @param conn MHD_Connection
+        /// @param data http 데이터
+        /// @param size http 데이터 크기
+        /// @return 0:성공, others:실패
+        int program_stop_accept(MHD_Connection* conn, const char* data, size_t* size, void** con_cls);
 
         /// @brief master 카메라일 경우 이벤트 발생
         /// @param group_name event group 이름

--- a/rpi_cam_app/include/http/HttpInitializer.hpp
+++ b/rpi_cam_app/include/http/HttpInitializer.hpp
@@ -22,18 +22,17 @@ namespace http
     void post_request_complete(
         void *cls, struct MHD_Connection* conn, void** con_cls, enum MHD_RequestTerminationCode toe);
 
-    class HttpInitializer : public utils::Initialzier, public utils::Singleton<HttpInitializer>
+    class HttpInitializer : public utils::Initialzier
     {
     private:
         std::string _uuid;
         const config::HttpConfig* _config;
         struct MHD_Daemon* _daemon;
 
-        friend utils::Singleton<HttpInitializer>;
-
-        HttpInitializer();
 
     public:
+        HttpInitializer();
+        
         int init() override;
         int start() override;
         int stop() override;

--- a/rpi_cam_app/include/video/VideoInitializer.hpp
+++ b/rpi_cam_app/include/video/VideoInitializer.hpp
@@ -13,16 +13,13 @@
 #include <thread>
 
 namespace video{
-    class VideoInitializer: public utils::Singleton<VideoInitializer>{
+    class VideoInitializer
+    {
     private:
-
-
         const config::VideoConfig* _vid_config;
         VideoStreamer* _streamer;
         VideoHandler* _handler;
 
-        friend utils::Singleton<VideoInitializer>; //Singleton이 이 클래스의 private 생성자에 접근 가능
-        VideoInitializer();
         std::mutex event_mutex;
         bool video_event_triggered = false;
         int event_timestamp;
@@ -33,6 +30,8 @@ namespace video{
         bool _remove_enable;
          
     public:
+        VideoInitializer();
+        
         void init();
         int start();
         int stop();

--- a/rpi_cam_app/src/CMakeLists.txt
+++ b/rpi_cam_app/src/CMakeLists.txt
@@ -6,8 +6,8 @@ add_executable(
     config/HttpConfig.cpp config/VideoConfig.cpp config/ProgramConfig.cpp config/CameraConfig.cpp
     http/EventHandlerHTTP.cpp http/HttpInitializer.cpp http/libmicrohttpd_handler.cpp http/post_request_complete.cpp
     video/VideoInitializer.cpp video/VideoHandler.cpp video/VideoStreamerGST.cpp
-    camera_device/VideoQueue.cpp
     camera_device/VideoQueue.cpp camera_device/CameraInitializer.cpp
+    event/EventHandler.cpp event/EventInitializer.cpp event/EventProcessor.cpp
 )
 
 target_include_directories(

--- a/rpi_cam_app/src/event/EventHandler.cpp
+++ b/rpi_cam_app/src/event/EventHandler.cpp
@@ -1,0 +1,35 @@
+#include "event/EventProcessor.hpp"
+#include "event/EventHandler.hpp"
+
+using namespace event;
+
+EventHandler::EventHandler()
+{
+    _video_q = camera_device::VideoQueue::get_instance();
+
+    _event_thread.clear();
+}
+
+int EventHandler::start_event(std::string name)
+{
+    EventProcessor* event = new EventProcessor(name);
+    _event_thread.emplace(name, event);
+    
+    std::thread event_t([=](){
+        event->event_loop();
+    });
+
+    event_t.detach();
+
+    return 0;
+}
+
+int EventHandler::stop_event(std::string name)
+{
+    _video_q->remove_event(name);
+
+    EventProcessor* event = _event_thread.find(name)->second;
+    delete event;
+
+    return 0;
+}

--- a/rpi_cam_app/src/event/EventInitializer.cpp
+++ b/rpi_cam_app/src/event/EventInitializer.cpp
@@ -1,0 +1,43 @@
+#include "event/EventProcessor.hpp"
+#include "event/EventHandler.hpp"
+#include "event/EventInitializer.hpp"
+#include "spdlog/spdlog.h"
+
+#include <filesystem>
+
+using namespace event;
+
+EventInitializer::EventInitializer()
+{
+    _event_handler = EventHandler::get_instance();
+}
+
+int EventInitializer::init()
+{
+    for(const auto& entry: std::filesystem::directory_iterator("event")){
+        std::string name = entry.path().filename().string();
+
+        int ret = _event_handler->start_event(name);
+        _event_names.push_back(name);
+
+        spdlog::info("Event \"{}\" started", name);
+    }
+
+    return 0 ;
+}
+
+int EventInitializer::start()
+{
+    spdlog::info("all event done!");
+
+    return 0;
+}
+
+int EventInitializer::stop()
+{
+    for(std::string& name : _event_names){
+        _event_handler->stop_event(name);
+    }
+
+    return 0;
+}

--- a/rpi_cam_app/src/event/EventProcessor.cpp
+++ b/rpi_cam_app/src/event/EventProcessor.cpp
@@ -1,0 +1,146 @@
+#include <dlfcn.h>
+#include <filesystem>
+#include <fstream>
+#include <exception>
+#include <string>
+#include <sstream>
+
+
+#include "event/EventProcessor.hpp"
+#include "http/EventHandlerHTTP.hpp"
+#include "spdlog/spdlog.h"
+
+using namespace event;
+
+static bool is_positive(const std::string& str)
+{
+    try {
+        int number = std::stoi(str);
+        if(number < 0) {
+            return false;
+        }
+        else{
+            return true;
+        }
+    } 
+    catch(const std::invalid_argument& ex) {
+        return false;
+    }
+    catch(const std::out_of_range& ex) {
+        return false;
+    }
+}
+
+EventProcessor::EventProcessor(std::string event_name)
+{
+
+    _video_q = camera_device::VideoQueue::get_instance();
+    _event_handler = http::EventHandlerHTTP::get_instance();
+    
+    _event_name.assign(event_name);
+
+    std::string event_directory("event/");
+    event_directory.append(event_name);
+
+    try {
+        for(const auto& entry : std::filesystem::directory_iterator(event_directory)){
+            const std::string& filename = entry.path().filename().string();
+            // enable 확인
+            if(filename == "enable"){
+                // 해당 파일을 읽어서 0이면 false, 아니면 true을 반환
+                std::ifstream enable_file(entry.path());
+                int enable;
+
+                if(enable_file >> enable) {
+                    _enable = static_cast<bool>(enable);
+                }
+            }
+            // 파일명이 양의 정수인지 확인
+            else if(is_positive(filename)){
+                _fps = std::stoi(filename);
+            }
+        }
+    }
+    catch(std::filesystem::filesystem_error& ex) {
+        spdlog::error("Error to Access Event Directory : {}", ex.what());
+    }
+
+    event_init();
+}
+
+int EventProcessor::event_init()
+{
+    std::stringstream so_stream;
+    so_stream << _event_name << ".so";
+
+    // open 시점에 로드
+    _handle = dlopen(so_stream.str().c_str(), RTLD_NOW);
+    if(_handle){
+        spdlog::error("Error Opening Event file {}", so_stream.str());
+        return 1;
+    }
+    // dlfcn error string 초기화
+    dlerror();
+
+    //  이벤트 프로그램의 시작함수인 event_main 함수를 찾아 링크
+    _event_program = (event_function)dlsym(_handle, "event_main");
+    const char* error = dlerror();
+    if(error) {
+        spdlog::error("Error link event program : {}", error);
+        dlclose(_handle);
+        return 2;
+    }
+
+    return 0;
+}
+
+int EventProcessor::event_exec(camera_device::VideoBuffer* buffer)
+{
+    int ret = -1;
+    ret = _event_program(
+            buffer->buffer,                         //  버퍼 내용
+            static_cast<size_t>((buffer->size)),    //  버퍼 크기
+            buffer->timestamp,                      //  해당 사진의 unix time
+            buffer->metadata.get_width(),           //  버퍼 너비
+            buffer->metadata.get_height()           //  버퍼 높이
+        );
+
+    if(ret<0){
+        spdlog::error("Event Program Interal Error");
+
+        return 1;
+    }
+    else if(ret) {
+        CURL* curl;
+        _event_handler->event_send(curl, "", buffer->timestamp);
+    }
+
+    return 0;
+}
+
+int EventProcessor::event_loop()
+{
+    int ret = 0;
+    
+    camera_device::ThreadInfo* info = new camera_device::ThreadInfo();
+    info->_fps = _fps;
+    info->_is_run = _enable;
+
+    _video_q->insert_event(_event_name, info);
+    while(_info->_is_run){
+
+        camera_device::VideoBuffer* buffer = _video_q->pop(_event_name);
+
+        if(buffer == nullptr) {
+            spdlog::warn("Event \"{}\" get nullptr buffer", _event_name);
+            break;
+        }
+
+        ret = event_exec(buffer);
+        if(ret){
+            //  이벤트 프로그램 내부 오류 발생
+        }
+    }
+
+    return 0;
+}

--- a/rpi_cam_app/src/http/libmicrohttpd_handler.cpp
+++ b/rpi_cam_app/src/http/libmicrohttpd_handler.cpp
@@ -31,6 +31,12 @@ MHD_Result http::libmicrohttpd_handler(
     else if(!strcmp(url, "/program") && !strcmp(method, "POST")) {
         ret =  static_cast<MHD_Result>(_handler->program_accept(conn, upload_data, data_size, con_cls));
     }
+    else if(!strcmp(url, "/program/start") && !strcmp(method, "POST")){
+        ret = static_cast<MHD_Result>(_handler->program_start_accept(conn, upload_data, data_size, con_cls));
+    }
+    else if(!strcmp(url, "/program/stop") && !strcmp(method, "POST")) {
+        ret = static_cast<MHD_Result>(_handler->program_stop_accept(conn, upload_data, data_size, con_cls));
+    }
     else {
         spdlog::warn("invalid request {} {}", method, url);
         

--- a/rpi_cam_app/src/main.cpp
+++ b/rpi_cam_app/src/main.cpp
@@ -3,6 +3,8 @@
 
 #include "video/VideoInitializer.hpp"
 #include "http/HttpInitializer.hpp"
+#include "camera_device/CameraInitializer.hpp"
+#include "event/EventInitializer.hpp"
 
 #include <atomic>
 #include <unistd.h>
@@ -14,43 +16,31 @@ int main(int argc, char const *argv[])
     spdlog::set_level(spdlog::level::info);
     config::ProgramConfig* config = config::ProgramConfig::get_instance();
 
-
-    //spdlog::set_level(spdlog::level::level_enum::debug);
     const config::HttpConfig* http = config->http_config();
-    spdlog::info("http");
-    spdlog::info("crt file path : {} ", http->crt_file());
-    spdlog::info("private file path : {}", http->private_file());
-    spdlog::info("thread pool : {}", http->thread_pool());
-    spdlog::info("tls enable : {}", http->tls_enable());
-
     const config::VideoConfig* vid = config->video_config();
-    spdlog::info("video");
-    spdlog::info( "{} * {}", vid->width(), vid->height());
-    spdlog::info("format {}", vid->format());
-    spdlog::info("{} {}", vid->split_time(), vid->duration());
-
     const config::CameraConfig* cam = config->camera_config();
-    spdlog::info("camera");
-    spdlog::info("{} * {}", cam->metadata().get_width(), cam->metadata().get_height());
-    spdlog::info("type {}",  cam->metadata().get_type());
-    spdlog::info("device path {}", cam->device_path());
-
 
     spdlog::info("init");
 
     //--------------------http------------------------
-    http::HttpInitializer* init = http::HttpInitializer::get_instance();
-
+    http::HttpInitializer* init = new http::HttpInitializer();
     init->init();
     init->start();
-    //--------------------video-----------------------
-    video::VideoInitializer* video_initializer = video::VideoInitializer::get_instance();
-    video::VideoHandler* video_handler = video::VideoHandler::get_instance(); 
 
+    //-------------------camera-----------------------
+    camera_device::CameraInitializer* cam_init = new camera_device::CameraInitializer();
+    cam_init->init();
+    cam_init->start();
+
+    //-------------------event-----------------------
+    event::EventInitializer* event_init = new event::EventInitializer();
+    event_init->init();
+    event_init->start();
+
+    //--------------------video-----------------------
+    video::VideoInitializer* video_initializer = new video::VideoInitializer();
     video_initializer->init();
     video_initializer->start();
-
-
 
     return 0;
 }


### PR DESCRIPTION
- 이벤트를 처리하는 로직으로 크게 2가지로 구성
- 이벤트 라이브러리를 로드하고 수행
  - EventProcessor는 라이브러리를 로드하고 loop를 수행
- EventProcessor를 관리
  - 스레드를 관리하는 것이 아닌 메모리를 관리
  - 스레드는 VideoQueue에서 관리함


- 통합
  - Initializer에서 싱글톤을 제거(main에서 직접 생성하고 수행하게 바꿈)
  - http는 의존적이지 않지만 camera->event->video는 순서 의존적
  - event는 camera가 동작하지 않으면 스레드가 동작하지 못하고, video는 마지막에 다른실행을 block하는 loop를 수행
  - 실행 순서 절대 바꾸지 마세요