### PR TITLE
VideoStreamer 수정

### DIFF
--- a/rpi_cam_app/include/video/VideoStreamerGST.hpp
+++ b/rpi_cam_app/include/video/VideoStreamerGST.hpp
@@ -3,29 +3,54 @@
 #define VIDEO_STREAMERGST_HPP
 
 #include <gst/gst.h>
+#include <gst/app/gstappsrc.h>
 #include <gst/rtsp-server/rtsp-server.h>
+#include <atomic>
+#include <unordered_map>
+
 #include "config/VideoConfig.hpp"
 #include "video/VideoStreamer.hpp"
+#include "camera_device/VideoQueue.hpp"
 
 namespace video{
-    class VideoStreamerGST: public VideoStreamer{
+
+    struct sess_info
+    {
+        std::string* id;
+        camera_device::ThreadInfo* info;
+    };
+    class VideoStreamerGST: public VideoStreamer
+    {
     private: 
-        GstRTSPServer *rtsp_server;
-        GstRTSPMountPoints *mountPoint;  // 클라이언트가 rtsp 서버에 접속할때 요청하는 url과 실제 미디어 스트림 연결 역할
-        GstRTSPMediaFactory *mfactory;   // rtsp 서버에서 스트리밍 할 미디어 파이프라인을 생성하는 객체
-        GMainLoop *main_loop;
-        std::string pipeline;
+    
+        GstRTSPServer* _rtsp_server;
+        // 클라이언트가 rtsp 서버에 접속할때 요청하는 url과 실제 미디어 스트림 연결 역할
+        GstRTSPMountPoints* _mountPoint;  
+        // rtsp 서버에서 스트리밍 할 미디어 파이프라인을 생성하는 객체
+        GstRTSPMediaFactory* _mfactory;   
+        // 실행흐름을 잡는 loop
+        GMainLoop* _main_loop;
+        //  rtsp streamer 파이프라인
+        std::string _pipeline;
+        //  컨피그 파일
         const config::VideoConfig* _video_config;
-        
+    
+        static void client_connected(GstRTSPServer* server, GstRTSPClient* client, gpointer user_data);
+
+        static void need_data(GstElement* appsrc, guint size, gpointer udata);
+        static void enough_data(GstElement* appsrc, gpointer user_data);
+        static void media_unprepared(GstRTSPMedia* media, gpointer user_data);
+        static void on_media_configure(GstRTSPMediaFactory* factory, GstRTSPMedia* media, gpointer user_data);
     public:
         VideoStreamerGST();
         ~VideoStreamerGST();
+
         std::string createPipeline(const config::VideoConfig* config);
         void make_server();
         int start_server() override;
         int stop_server() override;
         static gchar* format_location_callback(GstElement* splitmux, guint fragment_id, gpointer user_data);
-    };  
+    }; 
 };
 
 #endif 

--- a/rpi_cam_app/src/CMakeLists.txt
+++ b/rpi_cam_app/src/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(
     main.cpp
     config/HttpConfig.cpp config/VideoConfig.cpp config/ProgramConfig.cpp config/CameraConfig.cpp
     http/EventHandlerHTTP.cpp http/HttpInitializer.cpp http/libmicrohttpd_handler.cpp http/post_request_complete.cpp
-    video/VideoInitializer.cpp video/VideoHandler.cpp video/VideoStreamerGST.cpp
+    video/VideoInitializer.cpp video/VideoHandler.cpp video/VideoStreamerGST.cpp video/GstreamerCallbacks.cpp
     camera_device/VideoQueue.cpp camera_device/CameraInitializer.cpp
     event/EventHandler.cpp event/EventInitializer.cpp event/EventProcessor.cpp
 )
@@ -21,7 +21,7 @@ target_include_directories(
 # add link libraries
 target_link_libraries(
     main
-    gstreamer-1.0 gobject-2.0 glib-2.0 gstrtspserver-1.0
+    gstreamer-1.0 gobject-2.0 glib-2.0 gstrtspserver-1.0 gstrtsp-1.0 gstapp-1.0
     ssl crypto microhttpd curl
     boost_json
 )

--- a/rpi_cam_app/src/camera_device/CameraInitializer.cpp
+++ b/rpi_cam_app/src/camera_device/CameraInitializer.cpp
@@ -89,10 +89,10 @@ int CameraInitializer::set_v4l2_format()
     spdlog::info("====V4L2 set====");
     spdlog::info("size : {} * {}", format.fmt.pix.width, format.fmt.pix.height);
     spdlog::info("color map : {} {} {} {}", 
-        (format.fmt.pix.pixelformat)       & 0xFF,
-        (format.fmt.pix.pixelformat >> 8)  & 0xFF,
-        (format.fmt.pix.pixelformat >> 16) & 0xFF,
-        (format.fmt.pix.pixelformat >> 24) & 0xFF);
+        (char)((format.fmt.pix.pixelformat)       & 0xFF),
+        (char)((format.fmt.pix.pixelformat >> 8)  & 0xFF),
+        (char)((format.fmt.pix.pixelformat >> 16) & 0xFF),
+        (char)((format.fmt.pix.pixelformat >> 24) & 0xFF));
     
     if(ioctl(_fd, VIDIOC_S_FMT, &format) == -1) {
         spdlog::error("Failed to set video foramt");
@@ -146,7 +146,8 @@ int CameraInitializer::set_v4l2_buffer()
         }
 
         _camera_buffers[i] = (uint8_t*)mmap(NULL, buf.length, PROT_READ|PROT_WRITE, MAP_SHARED, _fd, buf.m.offset);
-    }
+    }  
+    spdlog::info("Buffer Request done");
 
     return 0;
 }
@@ -186,7 +187,7 @@ struct VideoBuffer* CameraInitializer::deque_v4l2_buffer(int* index)
 
     struct VideoBuffer* ret_buffer = new struct VideoBuffer;
 
-    ret_buffer->timestamp = static_cast<time_t>(dqbuf.timestamp.tv_sec);
+    ret_buffer->timestamp = time(NULL);
     ret_buffer->metadata = _cam_config->metadata();
     ret_buffer->size = dqbuf.bytesused;
     ret_buffer->buffer = (uint8_t*)malloc(dqbuf.bytesused);

--- a/rpi_cam_app/src/event/EventInitializer.cpp
+++ b/rpi_cam_app/src/event/EventInitializer.cpp
@@ -14,6 +14,7 @@ EventInitializer::EventInitializer()
 
 int EventInitializer::init()
 {
+    spdlog::info("Event Initialize Start ...");
     for(const auto& entry: std::filesystem::directory_iterator("event")){
         std::string name = entry.path().filename().string();
 
@@ -23,12 +24,14 @@ int EventInitializer::init()
         spdlog::info("Event \"{}\" started", name);
     }
 
-    return 0 ;
+    return 0;
 }
 
 int EventInitializer::start()
 {
-    spdlog::info("all event done!");
+    spdlog::info("=======================");
+    spdlog::info("===Event Initialized===");
+    spdlog::info("=======================");
 
     return 0;
 }

--- a/rpi_cam_app/src/main.cpp
+++ b/rpi_cam_app/src/main.cpp
@@ -28,10 +28,13 @@ int main(int argc, char const *argv[])
     init->start();
 
     //-------------------camera-----------------------
-    camera_device::CameraInitializer* cam_init = new camera_device::CameraInitializer();
-    cam_init->init();
-    cam_init->start();
-
+    std::thread camear_thread([&](){
+        camera_device::CameraInitializer* cam_init = new camera_device::CameraInitializer();
+        cam_init->init();
+        cam_init->start();
+    });
+    camear_thread.detach();
+    
     //-------------------event-----------------------
     event::EventInitializer* event_init = new event::EventInitializer();
     event_init->init();

--- a/rpi_cam_app/src/video/GstreamerCallbacks.cpp
+++ b/rpi_cam_app/src/video/GstreamerCallbacks.cpp
@@ -1,0 +1,209 @@
+#include "video/VideoStreamerGST.hpp"
+#include "spdlog/spdlog.h"
+
+#include <gst/rtsp-server/rtsp-media.h>
+#include <gst/rtsp-server/rtsp-client.h>
+#include <gst/rtsp-server/rtsp-context.h>
+#include <gst/rtsp-server/rtsp-session.h>
+
+#include <memory>
+
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+using namespace video;
+
+
+// format-location-full 콜백 함수
+// 새로운 파일이 생성될 때 호출
+// 파일 이름 timestamp로 
+gchar* VideoStreamerGST::format_location_callback(GstElement* splitmux, guint fragment_id, gpointer user_data) {
+    
+    time_t t = time(NULL);
+    std::string timestamp = std::to_string(t);
+    //std::string filename = "video_" + timestamp + ".mp4";
+    std::string filename =  "video/" + timestamp+".mp4";
+    spdlog::info("Saving new file: {}", filename);
+
+    // 파일 이름을 동적으로 반환
+    return g_strdup(filename.c_str());
+}
+
+
+void VideoStreamerGST::on_media_configure(GstRTSPMediaFactory* factory, GstRTSPMedia* media, gpointer user_data)
+{
+    spdlog::info("media-configure");
+    //  rtsp 파이프라인
+    GstElement* element = gst_rtsp_media_get_element(media);
+    //  appsrc 요소
+    GstElement* appsrc = gst_bin_get_by_name_recurse_up(GST_BIN(element), "stream_src");
+    //  muxsink 요소 찾아
+    GstElement* muxsink = gst_bin_get_by_name_recurse_up(GST_BIN(element), "muxsink");
+    
+    std::string* uuid = new std::string();
+
+    boost::uuids::random_generator generator;
+    boost::uuids::uuid uids = generator();
+    uuid->assign(boost::uuids::to_string(uids));
+    
+    //  VideoQueue 객체
+    camera_device::VideoQueue* video_q = camera_device::VideoQueue::get_instance();
+
+    camera_device::ThreadInfo* t_info = new camera_device::ThreadInfo();
+    t_info->_fps = 60;
+    t_info->_is_run = true;
+
+    struct sess_info* session = new sess_info();
+    session->id = uuid;
+    session->info = t_info; 
+    video_q->insert_event(*uuid, t_info); 
+    if(appsrc) {
+        // push-data
+        g_signal_connect(appsrc, "need-data", G_CALLBACK(VideoStreamerGST::need_data), session);
+        g_signal_connect(appsrc, "enough-data", G_CALLBACK(VideoStreamerGST::enough_data), session);
+
+        gst_object_unref(appsrc);
+    }
+    else{
+        
+        spdlog::error("Appsrc Not configured");
+    }
+    if(media) {
+        
+        g_signal_connect(media, "unprepared", G_CALLBACK(VideoStreamerGST::media_unprepared), session);
+
+    }
+    else {
+        spdlog::error("RTSPMeida not Configured");
+    }
+
+    if(muxsink) {
+        // splitmuxsink의 format-location-full 시그널에 콜백 연결
+        g_signal_connect(muxsink, "format-location-full", G_CALLBACK(format_location_callback), NULL);
+
+        g_object_unref(muxsink);
+    }
+
+    gst_object_unref(element);
+
+}
+void VideoStreamerGST::need_data(GstElement* appsrc, guint size, gpointer user_data)
+{
+    std::thread gst_thread([&](){
+        //  VideoQueue 객체
+        camera_device::VideoQueue* video_q = camera_device::VideoQueue::get_instance();
+        
+        if(user_data == nullptr) {
+            spdlog::warn("Session Info is nullptr");
+            return;
+        }
+        std::shared_ptr<struct sess_info> info(static_cast<struct sess_info*>(user_data));
+        std::string id = *info->id;
+
+        gint64 frame_duration = gst_util_uint64_scale(1, GST_SECOND, 30);
+        while(1) {
+
+            if(!GST_IS_APP_SRC(appsrc)) {
+                spdlog::error("Invalid appsrc element");
+                break;
+            }
+            //  VideoQueue에서 가져오는 데이터
+            camera_device::VideoBuffer* mem_buffer = video_q->pop(id);
+            if(mem_buffer == nullptr){
+                spdlog::warn("No Buffer at Queue");
+                break;
+            }
+
+            GstBuffer* buffer;
+            GstMapInfo map;
+            guint buffer_size = mem_buffer->size;
+
+            buffer = gst_buffer_new_allocate(NULL, mem_buffer->size, NULL);
+            if (!buffer) {
+                spdlog::error("Failed to allocate GstBuffer");
+                break;
+            }
+            if(!gst_buffer_map(buffer, &map, GST_MAP_WRITE)) {
+                spdlog::error("Failed to map buffer");
+                return;
+            }
+            if(mem_buffer->buffer == nullptr){
+                spdlog::error("Buffer is null");
+                break;
+            }
+            memcpy(map.data, mem_buffer->buffer, buffer_size);
+            gst_buffer_unmap(buffer, &map);
+
+        
+            // timestamp
+            gint64 timestamp = frame_duration * (_cnt);
+            GST_BUFFER_PTS(buffer) = timestamp;
+            GST_BUFFER_DTS(buffer) = timestamp;
+            GST_BUFFER_DURATION(buffer) = frame_duration;
+
+
+            // push data
+            if(gst_element_set_state(appsrc, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE){
+                spdlog::error("Appsrc Error");
+            }
+            else{
+                GstFlowReturn ret = gst_app_src_push_buffer(GST_APP_SRC(appsrc), buffer);
+                if(ret != GST_FLOW_OK) {
+                    spdlog::error("Failed to push buffer");
+                } else{
+                    _cnt++;
+                }
+            }
+            delete mem_buffer;
+        }
+        spdlog::info("video streaming thread end");
+    });
+    gst_thread.detach();
+
+}
+
+void VideoStreamerGST::enough_data(GstElement* appsrc, gpointer user_data)
+{
+
+    spdlog::warn("Enough Data to pipeline ");
+
+}
+
+void VideoStreamerGST::client_connected(GstRTSPServer* server, GstRTSPClient* client, gpointer user_data) 
+{
+    spdlog::info("connected");
+}
+
+void VideoStreamerGST::media_unprepared(GstRTSPMedia* media, gpointer user_data)
+{
+    if(user_data == nullptr){
+        return;
+    }
+    //  VideoQueue 객체
+    camera_device::VideoQueue* video_q = camera_device::VideoQueue::get_instance();
+    struct sess_info* info = static_cast<struct sess_info*>(user_data);
+    std::string sess_id;
+    sess_id.assign(info->id->c_str());
+    if(info==nullptr){
+        spdlog::warn("Session Info is nullptr");
+    }
+
+    //  파이프라인 중단
+    //  내부 파이프라인 가져오기
+    GstElement *pipeline = gst_rtsp_media_get_element(media);
+    if (pipeline) {
+        // 파이프라인을 NULL 상태로 변경하여 정지
+        gst_element_set_state(pipeline, GST_STATE_NULL);
+        spdlog::info("Pipeline stopped");
+
+        // 파이프라인 객체의 참조 해제
+        gst_object_unref(pipeline);
+    }
+
+    video_q->remove_event(*info->id);
+
+    delete info->id;
+    delete info->info;
+
+    delete info;
+}


### PR DESCRIPTION
카메라 디바이스에 중복 요청이 불가능
camera_device 에서 디바이스 요청을 진행하고, VideoStreamer를 이벤트의 하나로 처리

- v4l2src -> appsrc 추가
  - GstRTSPMediaFactory의 `media-configure`를 이용 `need-data`, `unprepared`, `enough-data`에 콜백을 등록 VideoQueue와 동기화
  - GstreamerCallbacks는 여기에 사용되는 콜백들을 하나로 모아둔 파일